### PR TITLE
Updated the manifest files to make the plugin work with the latest Nvda version

### DIFF
--- a/locale/pl/manifest.ini
+++ b/locale/pl/manifest.ini
@@ -1,1 +1,1 @@
-description = Wtyczka informująca o bieżącym wykorzystaniu zasobów przez aktywny proces
+description = Wtyczka informująca o bieżącym wykorzystaniu zasobów przez aktywny proces. Aby sprawdzić ścieżkę aktualnie używanego procesu oraz wykorzystywane przez niego zasoby wciśnij NVDA+Shift+F1, aby skopiować te informacje do schowka wciśnij skrót dwukrotnie. Jeśli chcesz, możesz zmienić skrót w zdarzeniach wejścia.

--- a/manifest.ini
+++ b/manifest.ini
@@ -1,6 +1,6 @@
 ﻿name = pinfo
 summary=pinfo
-description = A small plugin to report about current resource utilization by active process
+description = A small plugin to report about current resource utilization by active process. To check the path of the current process and resource utilization press NVDA+Shift+F1, to copy this information to the clipboard press the shortcut twice. If you want, you can change the shortcut in the input gestures settings.
 version = 0.1
 author = Dawid Pieper
-lastTestedNVDAVersion = 2020.3.0
+lastTestedNVDAVersion = 2021.1


### PR DESCRIPTION
Updated the manifest files to make the plugin work with the latest Nvda version
Added information about usage to the describtion. Addon is too small to create help files about usage, but information about the shortcuts will be usefull when someone forgot how to use the addon.
It's speeds up the process because noone must go to the repository to find information about shortcuts.